### PR TITLE
safe rbind in oa2df

### DIFF
--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -335,7 +335,7 @@ authors2df <- function(data, verbose = TRUE) {
       sub_affiliation <- prepend(sub_affiliation, "affiliation")
     }
 
-    list_df[[i]] <- tibble::as_tibble(c(sim_fields, sub_affiliation))
+    list_df[[i]] <- c(sim_fields, sub_affiliation)
   }
 
   col_order <- c(
@@ -346,7 +346,7 @@ authors2df <- function(data, verbose = TRUE) {
     "works_api_url"
   )
 
-  out_df <- do.call(rbind.data.frame, list_df)
+  out_df <- rbind_oa_ls(list_df)
   out_df[, intersect(col_order, names(out_df))]
 }
 
@@ -434,7 +434,7 @@ institutions2df <- function(data, verbose = TRUE) {
       fields$type,
       SIMPLIFY = FALSE
     )
-    list_df[[i]] <- tibble::as_tibble(sim_fields)
+    list_df[[i]] <- sim_fields
   }
 
 
@@ -447,7 +447,7 @@ institutions2df <- function(data, verbose = TRUE) {
     "works_api_url", "x_concepts", "updated_date", "created_date"
   )
 
-  out_df <- do.call(rbind.data.frame, list_df)
+  out_df <- rbind_oa_ls(list_df)
   out_df[, intersect(col_order, names(out_df))]
 }
 
@@ -530,7 +530,7 @@ venues2df <- function(data, verbose = TRUE) {
       fields$type,
       SIMPLIFY = FALSE
     )
-    list_df[[i]] <- tibble::as_tibble(sim_fields)
+    list_df[[i]] <- sim_fields
   }
 
   col_order <- c(
@@ -539,7 +539,7 @@ venues2df <- function(data, verbose = TRUE) {
     "counts_by_year", "x_concepts", "works_api_url", "type"
   )
 
-  out_df <- do.call(rbind.data.frame, list_df)
+  out_df <- rbind_oa_ls(list_df)
   out_df[, intersect(col_order, names(out_df))]
 }
 
@@ -633,7 +633,7 @@ concepts2df <- function(data, verbose = TRUE) {
       names(intern_fields) <- paste(names(intern_fields), "international", sep = "_")
     }
 
-    list_df[[i]] <- tibble::as_tibble(c(sim_fields, intern_fields))
+    list_df[[i]] <- c(sim_fields, intern_fields)
   }
 
   col_order <- c(
@@ -645,7 +645,7 @@ concepts2df <- function(data, verbose = TRUE) {
     "works_api_url"
   )
 
-  out_df <- do.call(rbind.data.frame, list_df)
+  out_df <- rbind_oa_ls(list_df)
   out_df[, intersect(col_order, names(out_df))]
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,12 +12,12 @@ simple_rapply <- function(x, fn, ...) {
 
 subs_na <- function(x, type = c("row_df", "col_df", "flat", "rbind_df", "identical"), prefix = NULL) {
   type <- match.arg(type)
-  if (type == "identical"){
-    return(x)
-  }
-
   if (length(x) == 0) {
     return(NA)
+  }
+
+  if (type == "identical") {
+    return(x)
   }
 
   out <- switch(type,
@@ -27,14 +27,14 @@ subs_na <- function(x, type = c("row_df", "col_df", "flat", "rbind_df", "identic
     rbind_df = do.call(rbind.data.frame, x)
   )
 
-  if (!is.null(prefix)){
+  if (!is.null(prefix)) {
     out <- prepend(out, prefix)
   }
 
   list(out)
 }
 
-prepend <- function(x, prefix = ""){
+prepend <- function(x, prefix = "") {
   names(x) <- paste(prefix, names(x), sep = "_")
   x
 }
@@ -69,7 +69,7 @@ id_type <- function(identifier) {
 
 oa_email <- function() {
   email <- Sys.getenv("openalexR.mailto")
-  if (email == ""){
+  if (email == "") {
     email <- getOption("openalexR.mailto", default = NULL)
   }
   email
@@ -77,7 +77,7 @@ oa_email <- function() {
 
 oa_apikey <- function() {
   apikey <- Sys.getenv("openalexR.apikey")
-  if (apikey == ""){
+  if (apikey == "") {
     apikey <- getOption("openalexR.apikey", default = NULL)
   }
   apikey
@@ -91,7 +91,9 @@ oa_progress <- function(n, text = "converting") {
 }
 
 asl <- function(z) {
-  if (length(z) > 1) return(z)
+  if (length(z) > 1) {
+    return(z)
+  }
 
   z_low <- tolower(z)
   if (z_low == "true" || z_low == "false") {
@@ -107,4 +109,20 @@ shorten_oaid <- function(id) {
 
 shorten_orcid <- function(id) {
   gsub("^https://orcid.org/", "", id)
+}
+
+rbind_oa_ls <- function(list_df) {
+  all_names <- unique(unlist(lapply(list_df, names)))
+  do.call(
+    rbind.data.frame,
+    lapply(
+      list_df,
+      function(x) {
+        tibble::as_tibble(c(x, sapply(
+          setdiff(all_names, names(x)),
+          function(y) NA
+        )))
+      }
+    )
+  )
 }


### PR DESCRIPTION
Previously, `do.call(rbind, ...)` errors out when the list elements don't have the same names. The new function `rbind_oa_ls` allows rbind to work and set unavailable names to NA, so this now works:

``` r
openalexR::oa_fetch("authors", display_name.search = "Trang T Le")
```