### PR TITLE
CRAN patch request to use string for comparing package versions

### DIFF
--- a/R/oa_ngrams.R
+++ b/R/oa_ngrams.R
@@ -63,7 +63,7 @@ oa_ngrams <- function(works_identifier, ...,
   pb <- oa_progress(n)
 
   # Fetch
-  if (utils::packageVersion("curl") >= 5) {
+  if (utils::packageVersion("curl") >= "5") {
     # Parallel fetch
     ngrams_files <- asNamespace("curl")$multi_download(query_urls, file.path(tempdir(), normalized_id), progress = verbose)
     ngrams_success <- ifelse(ngrams_files$success, ngrams_files$destfile, NA)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,5 @@
+* Small patch to use string for package version comparison
+
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
-
-* This is a new release.
+0 errors | 0 warnings | 0 note


### PR DESCRIPTION
Hi team -

Yesterday I received a CRAN email asking us to use string for comparing package versions for one of my own packages, and saw openalexR on the list as well. I realized that I was responsible for this in how I wrote `oa_ngrams()` - apologies!

This is a small PR to use `"5"` instead of `5` when checking for `{curl}` version. So it's now:

```
utils::packageVersion("curl") >= "5"
```

I also added a comment for CRAN telling them that we fixed it.

Thanks!