### PR TITLE
Fix SSL error in github actions by using wget

### DIFF
--- a/.github/workflows/check-pkgdown.yml
+++ b/.github/workflows/check-pkgdown.yml
@@ -27,7 +27,11 @@ jobs:
         - name: Install dependencies
           run: |
             options(download.file.method = "wget")
-            devtools::install_github("https://github.com/ropensci-org/rotemplate")
+            pkg <- "ropensci-org/rotemplate"
+            URL <- paste0("https://api.github.com/repos/", pkg, "/tarball")
+            tmp <- tempfile(fileext = ".tar.gz")
+            download.file(URL, tmp, method = "wget")
+            install.packages(tmp, type = "source")
           shell: Rscript {0}
 
         - name: Check pkgdown

--- a/.github/workflows/check-pkgdown.yml
+++ b/.github/workflows/check-pkgdown.yml
@@ -25,7 +25,9 @@ jobs:
             extra-packages: any::devtools, any::pkgdown
 
         - name: Install dependencies
-          run: devtools::install_github("https://github.com/ropensci-org/rotemplate")
+          run: |
+            options(download.file.method = "wget")
+            devtools::install_github("https://github.com/ropensci-org/rotemplate")
           shell: Rscript {0}
 
         - name: Check pkgdown


### PR DESCRIPTION
Just in case the issue persists and we decide to not just skip installing rotemplate.

Got some help on this from over at masstodon: https://fosstodon.org/@zkamvar/110741509849166583