### PR TITLE
Account for empty element in final_res

### DIFF
--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -47,6 +47,10 @@
 #'
 #' @export
 oa2df <- function(data, entity, count_only = FALSE, group_by = NULL, abstract = TRUE, verbose = TRUE) {
+  if (length(data) == 0){
+    return(NULL)
+  }
+
   if (!is.null(group_by)) {
     return(do.call(rbind.data.frame, data))
   }


### PR DESCRIPTION
Before this fix, we get an error because the 2nd element of [`final_res`](https://github.com/ropensci/openalexR/blob/71b8715687ab9c9e28f3fe6ab99e05ea01f3f26d/R/oa_fetch.R#L141) in the below computation is an empty list since the 2nd element of [`list_id`](https://github.com/ropensci/openalexR/blob/71b8715687ab9c9e28f3fe6ab99e05ea01f3f26d/R/oa_fetch.R#L104C23-L104C30) contains the last 2 works with no citations yet (W4301494992 and W87230806). 

``` r
library(openalexR)
my_papers <- c("W2741809807", "W2122130843", "W2041540760", "W2038196424", "W2396414759", "W2059275568", "W3130540911", "W2104791248", "W1553564559", "W2051771537", "W2144816075", "W2980172586", "W1519117689", "W4235038322", "W2014140050", "W2109312864", "W4229010617", "W4245410681", "W2143461694", "W2949258821", "W2017292130", "W3208256308", "W2290499851", "W854896339", "W2110180658", "W2244341329", "W2941875476", "W4287670050", "W104609242", "W1584777982", "W2112724334", "W2154768595", "W2223579979", "W2227647665", "W2287991258", "W2398849157", "W2550999367", "W2613086963", "W2789184385", "W28360414", "W2949915600", "W3041578807", "W3094060352", "W3168937413", "W3206844309", "W4230863633", "W4288680697", "W4299872130", "W4299955488", "W4301303362", "W4301494992", "W87230806")

citing_papers <- oa_fetch(
  "works",
  cites = my_papers,
  options = list(select = c("id", "publication_year", "referenced_works"))
)
#> Error in data[[i]]: subscript out of bounds
```

<sup>Created on 2023-07-31 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Now:
``` r
library(openalexR)
my_papers <- c("W2741809807", "W2122130843", "W2041540760", "W2038196424", "W2396414759", "W2059275568", "W3130540911", "W2104791248", "W1553564559", "W2051771537", "W2144816075", "W2980172586", "W1519117689", "W4235038322", "W2014140050", "W2109312864", "W4229010617", "W4245410681", "W2143461694", "W2949258821", "W2017292130", "W3208256308", "W2290499851", "W854896339", "W2110180658", "W2244341329", "W2941875476", "W4287670050", "W104609242", "W1584777982", "W2112724334", "W2154768595", "W2223579979", "W2227647665", "W2287991258", "W2398849157", "W2550999367", "W2613086963", "W2789184385", "W28360414", "W2949915600", "W3041578807", "W3094060352", "W3168937413", "W3206844309", "W4230863633", "W4288680697", "W4299872130", "W4299955488", "W4301303362", "W4301494992", "W87230806")

citing_papers <- oa_fetch(
  "works",
  cites = my_papers,
  options = list(select = c("id", "publication_year", "referenced_works"))
)
head(citing_papers)
#> # A tibble: 6 × 3
#>   id                               publication_year referenced_works
#>   <chr>                                       <int> <list>          
#> 1 https://openalex.org/W1965964177             2011 <chr [22]>      
#> 2 https://openalex.org/W2132862423             2014 <chr [28]>      
#> 3 https://openalex.org/W2073023209             2013 <chr [26]>      
#> 4 https://openalex.org/W2060737215             2013 <chr [35]>      
#> 5 https://openalex.org/W2164277894             2014 <chr [17]>      
#> 6 https://openalex.org/W2963475133             2014 <chr [50]>
```

<sup>Created on 2023-07-31 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
