### PR TITLE
Save pages returned by `oa_request()` and do not process further

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vignettes/*.R
 vignettes/*.html
 concept-abbre.csv
 dev/
+.lintr

--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -183,7 +183,8 @@ oa_fetch <- function(entity = if (is.null(identifier)) NULL else id_type(shorten
 #' If TRUE, print information about the querying process. Defaults to TRUE.
 #'
 #' @return a data.frame or a list of bibliographic records. If `save_pages` is
-#' not NULL the directory containing the saved pages is returned.
+#' not NULL a character vector containing the names of the saved pages
+#' is returned.
 #'
 #' For more extensive information about OpenAlex API, please visit:
 #' <https://docs.openalex.org>

--- a/man/oa_request.Rd
+++ b/man/oa_request.Rd
@@ -10,6 +10,7 @@ oa_request(
   paging = "cursor",
   pages = NULL,
   output_pages_to = NULL,
+  pages_save_function = saveRDS,
   count_only = FALSE,
   mailto = oa_email(),
   api_key = oa_apikey(),
@@ -43,6 +44,17 @@ The directory will be created if it does not exist.
 **The function will overwrite existing files in the directory without
 warning!**
 Defaults to NULL.}
+
+\item{pages_save_function}{Function.
+The function which will be used to save the individual pages if
+`output_pages_to` is set. This function has to take at least two arguments:
+  - the object to save (which will be the page returned in the same formnat 
+    as returned by the function `oa_request()`)
+  - the file name where to save it to (which is 
+    `file.path(output_pages_to, paste0("page_", i, ".rds"))`).
+This function can be used for example to save the results in a database or 
+a different format than `.rds`.
+Defaults to `saveRDS`.}
 
 \item{count_only}{Logical.
 If TRUE, the function returns only the number of item matching the query.

--- a/man/oa_request.Rd
+++ b/man/oa_request.Rd
@@ -8,6 +8,7 @@ oa_request(
   query_url,
   per_page = 200,
   paging = "cursor",
+  save_pages = NULL,
   count_only = FALSE,
   mailto = oa_email(),
   api_key = oa_apikey(),
@@ -28,6 +29,16 @@ Either "cursor" for cursor paging or "page" for basic paging.
 When used with options$sample, please set `paging = "page"`
 to avoid duplicates.}
 
+\item{save_pages}{Character.
+If NULL, the individual pages will be downloaded and processed in memory.
+This can, lead to memory issues if the amount downloaded is to large. To
+avoid this, set `save_pages` to a directory path. The individual pages
+downloaded will be saved in the directory specified by `save_pages`.
+The directory will be created if it dowes not exist.
+**The function will overwrite existing files in the directory without
+warning!**
+Defaults to NULL.}
+
 \item{count_only}{Logical.
 If TRUE, the function returns only the number of item matching the query.
 Defaults to FALSE.}
@@ -42,7 +53,9 @@ Your OpenAlex Premium API key, if available.}
 If TRUE, print information about the querying process. Defaults to TRUE.}
 }
 \value{
-a data.frame or a list of bibliographic records.
+a data.frame or a list of bibliographic records. If `save_pages` is
+not NULL a character vector containing the names of the saved pages
+is returned.
 
 For more extensive information about OpenAlex API, please visit:
 <https://docs.openalex.org>

--- a/man/oa_request.Rd
+++ b/man/oa_request.Rd
@@ -8,7 +8,7 @@ oa_request(
   query_url,
   per_page = 200,
   paging = "cursor",
-  save_pages = NULL,
+  output_pages_to = NULL,
   count_only = FALSE,
   mailto = oa_email(),
   api_key = oa_apikey(),
@@ -29,12 +29,11 @@ Either "cursor" for cursor paging or "page" for basic paging.
 When used with options$sample, please set `paging = "page"`
 to avoid duplicates.}
 
-\item{save_pages}{Character.
+\item{output_pages_to}{Character.
 If NULL, the individual pages will be downloaded and processed in memory.
-This can, lead to memory issues if the amount downloaded is to large. To
-avoid this, set `save_pages` to a directory path. The individual pages
-downloaded will be saved in the directory specified by `save_pages`.
-The directory will be created if it dowes not exist.
+If not NULL, the individual pages
+downloaded will be saved in the directory specified by `output_pages_to`.
+The directory will be created if it does not exist.
 **The function will overwrite existing files in the directory without
 warning!**
 Defaults to NULL.}
@@ -53,7 +52,7 @@ Your OpenAlex Premium API key, if available.}
 If TRUE, print information about the querying process. Defaults to TRUE.}
 }
 \value{
-a data.frame or a list of bibliographic records. If `save_pages` is
+a data.frame or a list of bibliographic records. If `output_pages_to` is
 not NULL a character vector containing the names of the saved pages
 is returned.
 


### PR DESCRIPTION
This is inspired by #166 

It is. not possible, due to memory limitations, to download a large number of works (thousands, millions). This pull request introduces an argument `save_pages` to the function `oa_request` which, if provided, saves all downloaded pages in the directory specified by the argument `save_pages`. No further processing of the downloaded pages is done, as this would again lead to memory problems, a vector containing the file names of the pages is returned.

This is at the moment a very rudimentary implementation, and could be tweaked further for performance, but I think this is not needed as a quick profiling indicated that the API calls take about 80% of the time, while the `saveRDS()` only 10%.