### PR TITLE
Resolves #187

### DIFF
--- a/vignettes/articles/Filters.Rmd
+++ b/vignettes/articles/Filters.Rmd
@@ -179,8 +179,8 @@ tech_insts <- oa_fetch(
 dplyr::glimpse(tech_insts)
 
 peer_venues <- oa_fetch(
-  entity = "venues", 
-  publisher = "Peerj",
+  entity = "sources", 
+  display_name = "PeerJ",
   x_concepts.id = "C185592680",
   is_oa = TRUE,
   is_in_doaj = TRUE

--- a/vignettes/articles/institution.Rmd
+++ b/vignettes/articles/institution.Rmd
@@ -44,7 +44,7 @@ The only difference here is that, instead of grouping by `is_oa`, we're interest
 open_access <- oa_fetch(
   entity = "works",
   institutions.ror = "00b30xv10",
-  type = "journal-article",
+  type = "article",
   from_publication_date = "2012-08-24",
   is_paratext = "false",
   is_oa = "true",
@@ -55,7 +55,7 @@ open_access <- oa_fetch(
 closed_access <- oa_fetch(
   entity = "works",
   institutions.ror = "00b30xv10",
-  type = "journal-article",
+  type = "article",
   from_publication_date = "2012-08-24",
   is_paratext = "false",
   is_oa = "false",


### PR DESCRIPTION
Looks like the doc build fails because of the deprecated usage of the "venues" entity in Filters.Rmd. This PR fixes this vignette.