### PR TITLE
empty filter check

### DIFF
--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -552,7 +552,7 @@ oa_query <- function(filter = NULL,
     filter <- filter[-empty_filters]
     stop(
       "Filters must have a value: ",
-      paste(names(empty_filters), collapse = ","),
+      paste(names(empty_filters), collapse = ", "),
       call. = FALSE
     )
   }

--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -547,6 +547,16 @@ oa_query <- function(filter = NULL,
   entity <- match.arg(entity, oa_entities())
   filter <- c(filter, list(...))
 
+  empty_filters <- which(lengths(filter) == 0)
+  if (length(empty_filters) > 0) {
+    filter <- filter[-empty_filters]
+    stop(
+      "Filters must have a value: ",
+      paste(names(empty_filters), collapse = ","),
+      call. = FALSE
+    )
+  }
+
   if (length(filter) > 0 || multiple_id) {
     null_locations <- vapply(filter, is.null, logical(1))
     filter[null_locations] <- NULL # remove NULL elements


### PR DESCRIPTION
Fixes #200 

`oa_query()` now errors if it receives a filter with a missing value, instead of silently ignoring it. Guards against users accidentally specifying a filter that ends up not doing anything.

```r
author_id <- NULL
author_works <- oa_fetch(
  entity = "works",
  author.id = author_id,
  publication_year = 2022,
  verbose = TRUE
)
#> Error: Filters must have a value: author.id
```