### PR TITLE
Add is_corresponding

### DIFF
--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -230,7 +230,7 @@ works2df <- function(data, abstract = TRUE, verbose = TRUE,
           } else {
             empty_list(c("au_id", "au_display_name", "au_orcid"))
           }
-          c(l_author, l["author_position"], aff_raw, first_inst)
+          c(l_author, l[c("author_position", "is_corresponding")], aff_raw, first_inst)
         }), "rbind_df"
       )
     }


### PR DESCRIPTION
Closes #205 

``` r
library(openalexR)
author_works <- oa_fetch(
  entity = "works",
  author.id = "a5016874418",
  publication_year = 2023,
  verbose = TRUE
)
#> Requesting url: https://api.openalex.org/works?filter=author.id%3Aa5016874418%2Cpublication_year%3A2023
#> Getting 1 page of results with a total of 9 records...

tail(author_works[[3]][[1]][,1:5])
#>                              au_id    au_display_name
#> 1 https://openalex.org/A5045990380  Mohanad Al-Obaidi
#> 2 https://openalex.org/A5011527972    Ahmet B. Gungor
#> 3 https://openalex.org/A5070604106      Sandra Kurtin
#> 4 https://openalex.org/A5027594045     Ann E. Mathias
#> 5 https://openalex.org/A5016874418    Bekir Tanrıöver
#> 6 https://openalex.org/A5076993071 Tirdad T. Zangeneh
#>                                au_orcid author_position is_corresponding
#> 1 https://orcid.org/0000-0002-5189-6594           first            FALSE
#> 2                                  <NA>          middle            FALSE
#> 3                                  <NA>          middle            FALSE
#> 4                                  <NA>          middle            FALSE
#> 5 https://orcid.org/0000-0002-2378-9302          middle            FALSE
#> 6 https://orcid.org/0000-0002-9035-2952            last             TRUE
```

<sup>Created on 2024-02-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>