### PR TITLE
Save raw json to enable download of large number of records

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
     covr
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Config/testthat/edition: 3
 Depends: 
     R (>= 2.10)

--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -187,6 +187,9 @@ oa_fetch <- function(entity = if (is.null(identifier)) NULL else id_type(shorten
 #' Your OpenAlex Premium API key, if available.
 #' @param verbose Logical.
 #' If TRUE, print information about the querying process. Defaults to TRUE.
+#' @param json_dir existing directory
+#' The directory to which the raw json files returned from OpenAlex will be written. If set,
+#' no processing of the jsons will be done and the function returns the json_dir path.
 #'
 #' @return a data.frame or a list of bibliographic records.
 #'

--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -354,7 +354,7 @@ oa_request <- function(
       Sys.sleep(1 / 10)
       query_ls[[paging]] <- next_page
       res <- api_request(query_url, ua, query = query_ls, json_dir = json_dir)
-      if (!is.null(json_dir)) {
+      if (is.null(json_dir)) {
         data <- c(data, res[[result_name]])
       }
       i <- i + 1
@@ -402,7 +402,7 @@ oa_request <- function(
     next_page <- get_next_page(paging, i, res)
     query_ls[[paging]] <- next_page
     res <- api_request(query_url, ua, query = query_ls, json_dir = json_dir)
-    if (!is.null(json_dir)) {
+    if (is.null(json_dir)) {
       if (!is.null(res[[result_name]])) data[[i]] <- res[[result_name]]
     }
   }

--- a/man/oa_request.Rd
+++ b/man/oa_request.Rd
@@ -12,7 +12,8 @@ oa_request(
   count_only = FALSE,
   mailto = oa_email(),
   api_key = oa_apikey(),
-  verbose = FALSE
+  verbose = FALSE,
+  json_dir = NULL
 )
 }
 \arguments{

--- a/man/oa_request.Rd
+++ b/man/oa_request.Rd
@@ -47,6 +47,10 @@ Your OpenAlex Premium API key, if available.}
 
 \item{verbose}{Logical.
 If TRUE, print information about the querying process. Defaults to TRUE.}
+
+\item{json_dir}{existing directory
+The directory to which the raw json files returned from OpenAlex will be written. If set,
+no processing of the jsons will be done and the function returns the json_dir path.}
 }
 \value{
 a data.frame or a list of bibliographic records.


### PR DESCRIPTION
This pull request adds a variable (`json_dir`) to the function `api_request()` and `oa_request()`. If set, the raw json files as returned by the call, per page, to OA and no further processing is done.

This makes the download of a large number of records possible, which would not have been possible by using the current approach.
In addition, it enables power users to process the json according to their needs, while not visible to the casual user, as this argument is not available in `oa_fetch()`.
This ala=so enables an efficient way of doing the conversion into a nibble as demonstrated at https://github.com/rkrug/openalexr_json/blob/b67560708abf711fdc0e5c9b26c2327e12b7cc1b/R/json_to_tibble.R.  At https://rkrug.github.io/openalexr_json/README.html you can see a timing comparison.

An additional bonus is, that the json files can be read directly into VOSViewer which makes it possible to link `openalexR` directly to further analysis with VOSViewer.
