### PR TITLE
Support for `output="raw"`

### DIFF
--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -22,6 +22,12 @@ oa_entities <- function() {
 #' The argument is ignored if entity is different from "works".
 #' @param output Character.
 #' Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"raw"`.
+##' \itemize{
+##'  \item{"tibble"}: {a tibble tidy data}
+##'  \item{"dataframe"}: {a base data.frame tidy data}
+##'  \item{"list"}: {a list of parsed JSON contents}
+##'  \item{"raw"}: {a list of raw JSON strings (length depends on query)}
+##' }
 #'
 #' @return A data.frame or a list. Result of the query.
 #' @export

--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -21,7 +21,7 @@ oa_entities <- function() {
 #' Default to \code{abstract = TRUE}.
 #' The argument is ignored if entity is different from "works".
 #' @param output Character.
-#' Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"json"`.
+#' Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"raw"`.
 #'
 #' @return A data.frame or a list. Result of the query.
 #' @export
@@ -68,7 +68,7 @@ oa_fetch <- function(entity = if (is.null(identifier)) NULL else id_type(shorten
                      options = NULL,
                      search = NULL,
                      group_by = NULL,
-                     output = c("tibble", "dataframe", "list", "json"),
+                     output = c("tibble", "dataframe", "list", "raw"),
                      abstract = TRUE,
                      endpoint = "https://api.openalex.org",
                      per_page = 200,
@@ -135,7 +135,7 @@ oa_fetch <- function(entity = if (is.null(identifier)) NULL else id_type(shorten
       count_only = count_only,
       mailto = mailto,
       api_key = api_key,
-      parse = output != "json",
+      parse = output != "raw",
       verbose = verbose
     )
   }
@@ -145,7 +145,7 @@ oa_fetch <- function(entity = if (is.null(identifier)) NULL else id_type(shorten
   }
   final_res <- unlist(final_res, recursive = FALSE)
 
-  if (output %in% c("list", "json")) {
+  if (output %in% c("list", "raw")) {
     return(final_res)
   }
 
@@ -404,13 +404,13 @@ oa_request <- function(query_url,
       res <- api_request(query_url, ua, query = query_ls, parse = TRUE)
       if (!is.null(res[[result_name]])) data[[i]] <- res[[result_name]]
     } else {
-      json <- api_request(query_url, ua, query = query_ls, parse = FALSE)
-      data[[i]] <- json
+      raw <- api_request(query_url, ua, query = query_ls, parse = FALSE)
+      data[[i]] <- raw
     }
   }
   data <- unlist(data, recursive = FALSE)
 
-  # `output = "json"` early exit
+  # `output = "raw"` early exit
   if (!parse) return(data)
 
   if (grepl("filter", query_url) && grepl("works", query_url)) {

--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -20,7 +20,8 @@ oa_entities <- function() {
 #' @param abstract Logical. If TRUE, the function returns also the abstract of each item.
 #' Default to \code{abstract = TRUE}.
 #' The argument is ignored if entity is different from "works".
-#' @param output Character. Type of output, either a list or a tibble/data.frame.
+#' @param output Character.
+#' Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"json"`.
 #'
 #' @return A data.frame or a list. Result of the query.
 #' @export
@@ -186,6 +187,8 @@ oa_fetch <- function(entity = if (is.null(identifier)) NULL else id_type(shorten
 #' Gives OpenAlex an email to enter the polite pool.
 #' @param api_key Character string.
 #' Your OpenAlex Premium API key, if available.
+#' @param parse Logical.
+#' If FALSE, returns the raw JSON response as string.
 #' @param verbose Logical.
 #' If TRUE, print information about the querying process. Defaults to TRUE.
 #'

--- a/man/oa_fetch.Rd
+++ b/man/oa_fetch.Rd
@@ -11,7 +11,7 @@ oa_fetch(
   options = NULL,
   search = NULL,
   group_by = NULL,
-  output = c("tibble", "dataframe", "list", "json"),
+  output = c("tibble", "dataframe", "list", "raw"),
   abstract = TRUE,
   endpoint = "https://api.openalex.org",
   per_page = 200,
@@ -67,7 +67,13 @@ For example: "oa_status" for works.
 See more at <https://docs.openalex.org/how-to-use-the-api/get-groups-of-entities>.}
 
 \item{output}{Character.
-Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"json"`.}
+Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"raw"`.
+\itemize{
+ \item{"tibble"}: {a tibble tidy data}
+ \item{"dataframe"}: {a base data.frame tidy data}
+ \item{"list"}: {a list of parsed JSON contents}
+ \item{"raw"}: {a list of raw JSON strings (length depends on query)}
+}}
 
 \item{abstract}{Logical. If TRUE, the function returns also the abstract of each item.
 Default to \code{abstract = TRUE}.

--- a/man/oa_fetch.Rd
+++ b/man/oa_fetch.Rd
@@ -11,7 +11,7 @@ oa_fetch(
   options = NULL,
   search = NULL,
   group_by = NULL,
-  output = c("tibble", "dataframe", "list"),
+  output = c("tibble", "dataframe", "list", "json"),
   abstract = TRUE,
   endpoint = "https://api.openalex.org",
   per_page = 200,
@@ -66,7 +66,8 @@ To filter using search, append .search to the end of the attribute you're filter
 For example: "oa_status" for works.
 See more at <https://docs.openalex.org/how-to-use-the-api/get-groups-of-entities>.}
 
-\item{output}{Character. Type of output, either a list or a tibble/data.frame.}
+\item{output}{Character.
+Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"json"`.}
 
 \item{abstract}{Logical. If TRUE, the function returns also the abstract of each item.
 Default to \code{abstract = TRUE}.

--- a/man/oa_random.Rd
+++ b/man/oa_random.Rd
@@ -17,7 +17,13 @@ c("works", "authors", "institutions", "concepts", "funders", "sources", "publish
 If not provided, `entity` is guessed from `identifier`.}
 
 \item{output}{Character.
-Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"json"`.}
+Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"raw"`.
+\itemize{
+ \item{"tibble"}: {a tibble tidy data}
+ \item{"dataframe"}: {a base data.frame tidy data}
+ \item{"list"}: {a list of parsed JSON contents}
+ \item{"raw"}: {a list of raw JSON strings (length depends on query)}
+}}
 
 \item{endpoint}{Character. URL of the OpenAlex Endpoint API server.
 Defaults to endpoint = "https://api.openalex.org".}

--- a/man/oa_random.Rd
+++ b/man/oa_random.Rd
@@ -16,7 +16,8 @@ The argument can be one of
 c("works", "authors", "institutions", "concepts", "funders", "sources", "publishers", "topics").
 If not provided, `entity` is guessed from `identifier`.}
 
-\item{output}{Character. Type of output, either a list or a tibble/data.frame.}
+\item{output}{Character.
+Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"json"`.}
 
 \item{endpoint}{Character. URL of the OpenAlex Endpoint API server.
 Defaults to endpoint = "https://api.openalex.org".}

--- a/man/oa_request.Rd
+++ b/man/oa_request.Rd
@@ -12,6 +12,7 @@ oa_request(
   count_only = FALSE,
   mailto = oa_email(),
   api_key = oa_apikey(),
+  parse = TRUE,
   verbose = FALSE
 )
 }
@@ -43,6 +44,9 @@ Gives OpenAlex an email to enter the polite pool.}
 
 \item{api_key}{Character string.
 Your OpenAlex Premium API key, if available.}
+
+\item{parse}{Logical.
+If FALSE, returns the raw JSON response as string.}
 
 \item{verbose}{Logical.
 If TRUE, print information about the querying process. Defaults to TRUE.}

--- a/tests/testthat/test-oa_fetch.R
+++ b/tests/testthat/test-oa_fetch.R
@@ -453,3 +453,37 @@ test_that("pages works", {
   )
   expect_equal(w1[11:20,], w2)
 })
+
+test_that("output=raw works", {
+  skip_on_cran()
+
+  output_raw <- oa_fetch(
+    entity = "works",
+    search = "language",
+    per_page = 2,
+    options = list(sample = 5, seed = 1),
+    output = "raw"
+  )
+
+  # length and type checks
+  expect_type(output_raw, "character")
+  expect_length(output_raw, ceiling(5 / 2)) # length determined by pages
+  raw_parsed <- lapply(output_raw, function(x) {
+    jsonlite::fromJSON(x, simplifyVector = FALSE)$results
+  })
+  expect_equal(lengths(raw_parsed), c(2, 2, 1)) # num results in each page
+  raw_parsed_flattened <- unlist(raw_parsed, recursive = FALSE)
+
+  # equivalence check to tibble format
+  expect_identical(
+    works2df(raw_parsed_flattened),
+    oa_fetch(
+      entity = "works",
+      search = "language",
+      per_page = 2,
+      options = list(sample = 5, seed = 1),
+      output = "tibble"
+    )
+  )
+
+})


### PR DESCRIPTION
This PR supports the option of `oa_fetch(output = "raw")` to return the raw JSON string(s) of the body of the API response, as-is. This is done in two parts:

1) The JSON parsing step in `api_request()` is now toggle-able. The default is to parse the JSON into R list, as before, but can be turned off with `api_request(parse = FALSE)`. When called from `oa_fetch(output = "raw")`, parsing is turned off.
2) When `output="raw"`, the result as returned by `api_request()` gets the same `output = "list"` treatment of returning early from `oa_fetch()`, avoiding further processing which assumes some structure in the result object.

The result of `output="raw"` is a character vector of raw JSON strings. The length depends on the implementational details of the query, namely the number of pages in the result.

```r
output_raw <- oa_fetch(
  entity = "works",
  search = "language",
  per_page = 2,
  options = list(sample = 5, seed = 1),
  output = "raw"
)
sapply(output_raw, substr, 1, 60, USE.NAMES = FALSE)
#> [1] "{\"meta\":{\"count\":5,\"db_response_time_ms\":201,\"page\":1,\"per_p"
#> [2] "{\"meta\":{\"count\":5,\"db_response_time_ms\":103,\"page\":2,\"per_p"
#> [3] "{\"meta\":{\"count\":5,\"db_response_time_ms\":66,\"page\":3,\"per_pa"
```

Some tests of equivalence to other output formats:

1) Equivalence to `output = "list"`

    ```r
    output_list <- oa_fetch(
      entity = "works",
      search = "language",
      per_page = 2,
      options = list(sample = 5, seed = 1),
      output = "list"
    )
    
    raw2list <- function(x) {
      parsed <- lapply(x, jsonlite::fromJSON, simplifyVector = FALSE)
      results <- sapply(parsed, `[[`, "results")
      unlist(results, recursive = FALSE, use.names = FALSE)
    }
    
    waldo::compare(
      raw2list(output_raw), output_list,
      list_as_map = TRUE
    )
    #> ✔ No differences
    ```

2) Equivalence to `output = "tibble"`

    ```r
    output_tibble <- oa_fetch(
      entity = "works",
      search = "language",
      per_page = 2,
      options = list(sample = 5, seed = 1),
      output = "tibble"
    )
    identical(
      output_raw %>% raw2list() %>% works2df(),
      output_tibble
    )
    #> [1] TRUE
    ```
    
 A power user now has more flexibility to intervene in the processing pipeline. For example, if they prefer to use another JSON parser:
 
```r
raw2list_fast <- function(x) {
  parsed <- lapply(x, RcppSimdJson::fparse, max_simplify_lvl = 3L, empty_array = list())
  results <- lapply(parsed, `[[`, "results")
  unlist(results, recursive = FALSE, use.names = FALSE)
}
bench::mark(
  jsonlite = raw2list(raw),
  RcppSimdJson = raw2list_fast(raw)
)
#> # A tibble: 2 × 6
#>   expression        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 jsonlite       1.71ms   1.95ms      502.    12.5KB     2.03
#> 2 RcppSimdJson  498.3µs  632.2µs     1421.    12.5KB    11.4
```