### PR TITLE
Parse Works objects `publication_date` field as date type

### DIFF
--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -200,7 +200,9 @@ works2df <- function(data, abstract = TRUE, verbose = TRUE,
       fields$type,
       SIMPLIFY = FALSE
     )
-    sim_fields$publication_date <- as.Date(sim_fields$publication_date)
+    if (!is.null(sim_fields$publication_date)) {
+      sim_fields$publication_date <- as.Date(sim_fields$publication_date)
+    }
 
     author <- venue <- ab <- NULL
 

--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -200,6 +200,7 @@ works2df <- function(data, abstract = TRUE, verbose = TRUE,
       fields$type,
       SIMPLIFY = FALSE
     )
+    sim_fields$publication_date <- as.Date(sim_fields$publication_date)
 
     author <- venue <- ab <- NULL
 


### PR DESCRIPTION
The `as.Date()` conversion of the `publication_date` gets the job done but is clunky and applied very narrowly.

I went through the API docs and there are only the two other places where the API returns date values: `updated_date` and `created_date`. These are OpenAlex-specific metadata and `oa2df()` sometimes returns them depending on the entity. I have less thoughts on these guys.

Date values aren't automatically converted by the JSON parser, like how integer/double/logical/etc. are - not sure if we want a bigger discussion around that (but perhaps at least not at this stage, given how rare date fields are?)