### PR TITLE
Respect `output = "raw"` in `oa_fetch()` when result is returned early

### DIFF
--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -335,12 +335,17 @@ oa_request <- function(query_url,
   }
 
   # first, download info about n. of items returned by the query
-  res <- api_request(query_url, ua, query = query_ls, api_key = api_key)
+  res <- api_request(query_url, ua, query = query_ls, api_key = api_key, parse = FALSE)
+  res_parsed <- jsonlite::fromJSON(res, simplifyVector = FALSE)
+  res_meta <- res_parsed$meta
+  if (parse) {
+    res <- res_parsed
+  }
 
-  if (!is.null(res$meta)) {
+  if (!is.null(res_meta)) {
     ## return only item counting
     if (count_only) {
-      return(res$meta)
+      return(res_meta)
     }
   } else {
     return(res)
@@ -368,7 +373,7 @@ oa_request <- function(query_url,
     return(data)
   }
 
-  n_items <- res$meta$count
+  n_items <- res_meta$count
   n_pages <- ceiling(n_items / per_page)
 
   ## number of pages


### PR DESCRIPTION
In `oa_fetch()`, there's a clause to return `res` (the single initial query we do at the start to compute on metadata for stuff like # of pages to expect) early when the `meta` field is empty (i.e., simple "direct" queries):

https://github.com/ropensci/openalexR/blob/42f4d1678574f61108dfb5f21c7ad4271c242295/R/oa_fetch.R#L340-L347

At this point of early return, `res` is always the parsed json, so it was not respecting `output = "raw"` in cases like `oa_fetch(identifier = "W4396214724", output = "raw")` which triggers that early return. 

The PR makes it so that this initial `res` can stay either parsed or unparsed, so that it can be returned unparsed if user specifies `output = "raw"`. Since we do need the parsed metadata info, that's now tracked in `res_meta`. The roundabout way of doing this in the code is to ensure that we only request once and parse as needed.