### PR TITLE
fix apc processing for W2101805856

### DIFF
--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -230,10 +230,10 @@ works2df <- function(data, abstract = TRUE, verbose = TRUE,
     apc <- NULL
     if (any(lengths(paper[c("apc_list", "apc_paid")]) > 0)) {
       apc_fields <- list(value = NA, currency = NA, value_usd = NA, provenance = NA)
-      apc <- list(rbind_oa_ls(list(
+      apc <- list(rbind.data.frame(
         c(type = "list", utils::modifyList(apc_fields, replace_w_na(paper$apc_list))),
         c(type = "paid", utils::modifyList(apc_fields, replace_w_na(paper$apc_paid)))
-      )))
+      ))
     }
     topics <- process_topics(paper, "score")
     out_ls <- c(sim_fields, venue, source, open_access, paper_biblio,

--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -230,10 +230,10 @@ works2df <- function(data, abstract = TRUE, verbose = TRUE,
     apc <- NULL
     if (any(lengths(paper[c("apc_list", "apc_paid")]) > 0)) {
       apc_fields <- list(value = NA, currency = NA, value_usd = NA, provenance = NA)
-      apc <- list(rbind.data.frame(
-        c(type = "list", utils::modifyList(apc_fields, as.list(paper$apc_list))),
-        c(type = "paid", utils::modifyList(apc_fields, as.list(paper$apc_paid)))
-      ))
+      apc <- list(rbind_oa_ls(list(
+        c(type = "list", utils::modifyList(apc_fields, replace_w_na(paper$apc_list))),
+        c(type = "paid", utils::modifyList(apc_fields, replace_w_na(paper$apc_paid)))
+      )))
     }
     topics <- process_topics(paper, "score")
     out_ls <- c(sim_fields, venue, source, open_access, paper_biblio,

--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -230,7 +230,8 @@ works2df <- function(data, abstract = TRUE, verbose = TRUE,
     apc <- NULL
     if (any(lengths(paper[c("apc_list", "apc_paid")]) > 0)) {
       apc_fields <- list(
-        value = NA_real_, currency = NA, value_usd = NA_real_, provenance = NA
+        value = NA_real_, currency = NA_character_,
+        value_usd = NA_real_, provenance = NA_character_
       )
       apc_list <- paper$apc_list[lengths(paper$apc_list) != 0]
       apc_paid <- paper$apc_paid[lengths(paper$apc_paid) != 0]

--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -229,10 +229,14 @@ works2df <- function(data, abstract = TRUE, verbose = TRUE,
     # Process APC
     apc <- NULL
     if (any(lengths(paper[c("apc_list", "apc_paid")]) > 0)) {
-      apc_fields <- list(value = NA, currency = NA, value_usd = NA, provenance = NA)
+      apc_fields <- list(
+        value = NA_real_, currency = NA, value_usd = NA_real_, provenance = NA
+      )
+      apc_list <- paper$apc_list[lengths(paper$apc_list) != 0]
+      apc_paid <- paper$apc_paid[lengths(paper$apc_paid) != 0]
       apc <- list(rbind.data.frame(
-        c(type = "list", utils::modifyList(apc_fields, replace_w_na(paper$apc_list))),
-        c(type = "paid", utils::modifyList(apc_fields, replace_w_na(paper$apc_paid)))
+        c(type = "list", utils::modifyList(apc_fields, as.list(apc_list))),
+        c(type = "paid", utils::modifyList(apc_fields, as.list(apc_paid)))
       ))
     }
     topics <- process_topics(paper, "score")


### PR DESCRIPTION
Closes #305. 

``` r
library(openalexR)
paper <- oa_fetch(identifier = "W2101805856", output = "list")
paper$apc_list
#> $value
#> [1] 3500000
#> 
#> $currency
#> [1] "IRR"
#> 
#> $value_usd
#> NULL
#> 
#> $provenance
#> [1] "doaj"
if (any(lengths(paper[c("apc_list", "apc_paid")]) > 0)) {
  apc_fields <- list(value = NA, currency = NA, value_usd = NA, provenance = NA)
  apc <- list(rbind.data.frame(list(
    c(type = "list", utils::modifyList(apc_fields, as.list(paper$apc_list))),
    c(type = "paid", utils::modifyList(apc_fields, as.list(paper$apc_paid)))
  )))
}
#> Error in rbind.data.frame(list(c(type = "list", utils::modifyList(apc_fields, : invalid list argument: all variables should have the same length

# my current fix is to use `replace_w_na` but open to more elegant solution
if (any(lengths(paper[c("apc_list", "apc_paid")]) > 0)) {
  apc_fields <- list(value = NA, currency = NA, value_usd = NA, provenance = NA)
  apc <- list(rbind.data.frame(
    c(type = "list", utils::modifyList(apc_fields, openalexR:::replace_w_na(paper$apc_list))),
    c(type = "paid", utils::modifyList(apc_fields, openalexR:::replace_w_na(paper$apc_paid)))
  ))
}
apc
#> [[1]]
#>   type   value currency value_usd provenance
#> 1 list 3500000      IRR        NA       doaj
#> 2 paid      NA     <NA>        NA       <NA>
```

<sup>Created on 2024-12-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
