### PR TITLE
Fix group_by for boolean groups

### DIFF
--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -355,6 +355,11 @@ oa_request <- function(query_url,
   query_ls[["per-page"]] <- per_page
 
   if (is_group_by) {
+    # cursor pagination only when the number of groups is greater than per_page
+    if (res$meta$groups_count < per_page) {
+      return(res[[result_name]])
+    }
+
     data <- vector("list")
     res <- NULL
     i <- 1

--- a/tests/testthat/test-group_by.R
+++ b/tests/testthat/test-group_by.R
@@ -1,0 +1,22 @@
+
+test_that("search and group_by works", {
+  # https://github.com/ropensci/openalexR/issues/327
+  g1 <- oa_fetch(
+    title_and_abstract.search = "nature",
+    group_by = "topics.subfield.id"
+  )
+  expect_s3_class(g1, "data.frame")
+  expect_equal(colnames(g1), c("key", "key_display_name", "count"))
+
+})
+
+test_that("group_by works", {
+  # https://github.com/ropensci/openalexR/issues/327
+
+  # grouping by the boolean "is_oa" should return 2 rows
+  g2 <- oa_fetch(entity = "works", search = "biodiversity", group_by = "is_oa")
+  expect_s3_class(g2, "data.frame")
+  expect_equal(nrow(g2), 2)
+  expect_equal(colnames(g2), c("key", "key_display_name", "count"))
+})
+

--- a/tests/testthat/test-oa_fetch.R
+++ b/tests/testthat/test-oa_fetch.R
@@ -425,8 +425,8 @@ test_that("different paging methods yield the same result", {
   )
 
   expect_equal(
-    w0[c(11:20, 31:min(50, nrow(w0))), ],
-    w24
+    sort(w0[c(11:20, 31:min(50, nrow(w0))), ]$id),
+    sort(w24$id)
   )
 
 })
@@ -437,14 +437,14 @@ test_that("pages works", {
   # The last 10 pages when per_page = 20
   # should be the same as the 10 pages when fetching page 2
   w1 <- oa_fetch(
-    search = "transformative change",
+    title.search = "transformative change",
     options = list(select = c("id", "display_name", "publication_date")),
     pages = 1,
     per_page = 20,
     verbose = TRUE
   )
   w2 <- oa_fetch(
-    search = "transformative change",
+    title.search = "transformative change",
     options = list(select = c("id", "display_name", "publication_date")),
     pages = 2,
     per_page = 10,


### PR DESCRIPTION
During paging, we can't add `cursor=*` to the [URL](
https://api.openalex.org/works?search=biodiversity&group_by=is_oa&cursor=*) because 

> Cannot use cursor pagination when grouping fields that return true or false.


We now limit pagination to only when there are more groups than `per_page`.